### PR TITLE
feat: add configurable request timeout support

### DIFF
--- a/config/waha-saloon-sdk.php
+++ b/config/waha-saloon-sdk.php
@@ -41,6 +41,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Timeout Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure the connection and request timeouts (in seconds) for the
+    | WAHA API. The request timeout should be generous enough for media
+    | operations (sendImage, sendVideo, etc.) where WAHA downloads and
+    | processes files server-side before sending.
+    |
+    */
+    'timeout' => env('WAHA_REQUEST_TIMEOUT', 60),
+    'connect_timeout' => env('WAHA_CONNECT_TIMEOUT', 10),
+
+    /*
+    |--------------------------------------------------------------------------
     | Legacy Configuration (Backward Compatibility)
     |--------------------------------------------------------------------------
     |

--- a/src/Waha/Waha.php
+++ b/src/Waha/Waha.php
@@ -106,12 +106,19 @@ use CCK\LaravelWahaSaloonSdk\Waha\Resource\Video;
 use CCK\LaravelWahaSaloonSdk\Waha\Resource\Views;
 use CCK\LaravelWahaSaloonSdk\Waha\Resource\Voice;
 use Saloon\Http\Connector;
+use Saloon\Traits\Plugins\HasTimeout;
 
 /**
  * WAHA - WhatsApp HTTP API
  */
 class Waha extends Connector
 {
+    use HasTimeout;
+
+    protected int $connectTimeout = 10;
+
+    protected int $requestTimeout = 60;
+
     public function __construct(
         public string $baseUrl = '',
         protected ?string $apiKey = null,
@@ -127,6 +134,11 @@ class Waha extends Connector
             $this->apiKey = config('waha-saloon-sdk.connections.default.api_key')
                 ?? config('waha-saloon-sdk.api_key')
                 ?? null;
+        }
+
+        if (function_exists('config')) {
+            $this->connectTimeout = (int) (config('waha-saloon-sdk.connect_timeout') ?? $this->connectTimeout);
+            $this->requestTimeout = (int) (config('waha-saloon-sdk.timeout') ?? $this->requestTimeout);
         }
     }
 

--- a/tests/Unit/WahaTimeoutTest.php
+++ b/tests/Unit/WahaTimeoutTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use CCK\LaravelWahaSaloonSdk\Waha\Waha;
+
+describe('Waha Timeout', function () {
+    it('has default timeout values', function () {
+        $waha = new Waha(baseUrl: 'https://example.com');
+
+        expect($waha->getConnectTimeout())->toBe(10.0)
+            ->and($waha->getRequestTimeout())->toBe(60.0);
+    });
+
+    it('reads timeout from config', function () {
+        config()->set('waha-saloon-sdk.connect_timeout', 5);
+        config()->set('waha-saloon-sdk.timeout', 120);
+
+        $waha = new Waha(baseUrl: 'https://example.com');
+
+        expect($waha->getConnectTimeout())->toBe(5.0)
+            ->and($waha->getRequestTimeout())->toBe(120.0);
+    });
+
+    it('falls back to defaults when config is not set', function () {
+        config()->set('waha-saloon-sdk.connect_timeout', null);
+        config()->set('waha-saloon-sdk.timeout', null);
+
+        $waha = new Waha(baseUrl: 'https://example.com');
+
+        expect($waha->getConnectTimeout())->toBe(10.0)
+            ->and($waha->getRequestTimeout())->toBe(60.0);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds Saloon's `HasTimeout` trait to the `Waha` connector with defaults of 10s connect / 60s request timeout
- Timeout values are configurable via `config/waha-saloon-sdk.php` and env vars (`WAHA_REQUEST_TIMEOUT`, `WAHA_CONNECT_TIMEOUT`)
- Prevents `cURL error 28` timeouts on media operations (`sendImage`, `sendVideo`, `sendFile`) where WAHA downloads files server-side

Closes #8

## Test plan

- [x] Tests for default timeout values
- [x] Tests for reading timeout from config
- [x] Tests for fallback to defaults when config is null
- [x] PHPStan passes on modified files
- [x] Full test suite passes (20 tests, 39 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)