### PR TITLE
feat: add configurable AlwaysThrowOnErrors middleware

### DIFF
--- a/config/waha-saloon-sdk.php
+++ b/config/waha-saloon-sdk.php
@@ -55,6 +55,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Always Throw On Errors
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, non-2xx responses will automatically throw a
+    | RequestException instead of returning a response object. This
+    | prevents misleading JsonException errors when calling ->json()
+    | on error responses (e.g. HTML error pages, empty bodies).
+    |
+    */
+    'always_throw_on_errors' => env('WAHA_ALWAYS_THROW_ON_ERRORS', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Legacy Configuration (Backward Compatibility)
     |--------------------------------------------------------------------------
     |

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,7 +3,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 5
+			count: 8
 			path: config/waha-saloon-sdk.php
 
 		-

--- a/src/Waha/Waha.php
+++ b/src/Waha/Waha.php
@@ -105,7 +105,9 @@ use CCK\LaravelWahaSaloonSdk\Waha\Resource\Version;
 use CCK\LaravelWahaSaloonSdk\Waha\Resource\Video;
 use CCK\LaravelWahaSaloonSdk\Waha\Resource\Views;
 use CCK\LaravelWahaSaloonSdk\Waha\Resource\Voice;
+use Saloon\Enums\PipeOrder;
 use Saloon\Http\Connector;
+use Saloon\Http\Response;
 use Saloon\Traits\Plugins\HasTimeout;
 
 /**
@@ -139,6 +141,14 @@ class Waha extends Connector
         if (function_exists('config')) {
             $this->connectTimeout = (int) (config('waha-saloon-sdk.connect_timeout') ?? $this->connectTimeout);
             $this->requestTimeout = (int) (config('waha-saloon-sdk.timeout') ?? $this->requestTimeout);
+
+            if (config('waha-saloon-sdk.always_throw_on_errors', true)) {
+                $this->middleware()->onResponse(
+                    callable: static fn (Response $response) => $response->throw(),
+                    name: 'alwaysThrowOnErrors',
+                    order: PipeOrder::LAST,
+                );
+            }
         }
     }
 

--- a/tests/Unit/WahaAlwaysThrowOnErrorsTest.php
+++ b/tests/Unit/WahaAlwaysThrowOnErrorsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use CCK\LaravelWahaSaloonSdk\Waha\Waha;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+describe('Waha AlwaysThrowOnErrors', function () {
+    it('throws RequestException on error responses by default', function () {
+        config()->set('waha-saloon-sdk.always_throw_on_errors', true);
+
+        $waha = new Waha(baseUrl: 'https://example.com');
+
+        $mockClient = new MockClient([
+            MockResponse::make('Internal Server Error', 500),
+        ]);
+
+        $waha->withMockClient($mockClient);
+
+        $waha->sessions()->getSessionInformation('test', null);
+    })->throws(Saloon\Exceptions\Request\RequestException::class);
+
+    it('does not throw when always_throw_on_errors is disabled', function () {
+        config()->set('waha-saloon-sdk.always_throw_on_errors', false);
+
+        $waha = new Waha(baseUrl: 'https://example.com');
+
+        $mockClient = new MockClient([
+            MockResponse::make('Internal Server Error', 500),
+        ]);
+
+        $waha->withMockClient($mockClient);
+
+        $response = $waha->sessions()->getSessionInformation('test', null);
+
+        expect($response->status())->toBe(500);
+    });
+});

--- a/tests/Unit/WahaAlwaysThrowOnErrorsTest.php
+++ b/tests/Unit/WahaAlwaysThrowOnErrorsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use CCK\LaravelWahaSaloonSdk\Waha\Waha;
+use Saloon\Exceptions\Request\RequestException;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
@@ -17,7 +18,7 @@ describe('Waha AlwaysThrowOnErrors', function () {
         $waha->withMockClient($mockClient);
 
         $waha->sessions()->getSessionInformation('test', null);
-    })->throws(Saloon\Exceptions\Request\RequestException::class);
+    })->throws(RequestException::class);
 
     it('does not throw when always_throw_on_errors is disabled', function () {
         config()->set('waha-saloon-sdk.always_throw_on_errors', false);

--- a/tests/Unit/WahaManagerTest.php
+++ b/tests/Unit/WahaManagerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use CCK\LaravelWahaSaloonSdk\Waha\Resource\Sessions;
 use CCK\LaravelWahaSaloonSdk\Waha\Waha;
 use CCK\LaravelWahaSaloonSdk\WahaManager;
 
@@ -166,6 +167,6 @@ describe('WahaManager', function () {
         // The sessions() method should be proxied to the default connection
         $sessions = $manager->sessions();
 
-        expect($sessions)->toBeInstanceOf(\CCK\LaravelWahaSaloonSdk\Waha\Resource\Sessions::class);
+        expect($sessions)->toBeInstanceOf(Sessions::class);
     });
 });


### PR DESCRIPTION
## Summary

- Registers Saloon's `AlwaysThrowOnErrors` response middleware on the `Waha` connector so non-2xx responses throw `RequestException` instead of causing misleading `JsonException` when calling `->json()`
- Enabled by default, configurable via `WAHA_ALWAYS_THROW_ON_ERRORS` env var (set to `false` to opt out)
- Regenerated PHPStan baseline for new config `env()` call

Closes #12

## Test plan

- [x] Test that error responses throw `RequestException` when enabled (default)
- [x] Test that error responses return normally when disabled
- [x] Full test suite passes (22 tests, 41 assertions)
- [x] PHPStan and Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)